### PR TITLE
Change Dates to year/month/day tuples

### DIFF
--- a/src/Conferences.elm
+++ b/src/Conferences.elm
@@ -1,7 +1,7 @@
 module Conferences (..) where
 
-import Date
-import DateFormatter exposing (parseDate)
+import Date exposing (Month(..))
+import DateFormatter exposing (DaTuple)
 
 
 type alias Model =
@@ -13,8 +13,8 @@ type alias Model =
 type alias Conference =
     { name : String
     , link : String
-    , startDate : Date.Date
-    , endDate : Date.Date
+    , startDate : DaTuple
+    , endDate : DaTuple
     , location : String
     , tags : List Tag
     }
@@ -288,1436 +288,1443 @@ list =
     { conferences =
         [ { name = "@Swift"
           , link = "http://atswift.io/index-en.html"
-          , startDate = parseDate "2016-01-10"
-          , endDate = parseDate "2016-01-10"
+          , startDate = ( 2016, Jan, 10 )
+          , endDate = ( 2016, Jan, 10 )
           , location = "Beijing, China"
           , tags = [ English, Developers, China, Swift, IOS ]
           }
         , { name = "NDC London Workshops"
           , link = "http://ndc-london.com/"
-          , startDate = parseDate "2016-01-11"
-          , endDate = parseDate "2016-01-12"
+          , startDate = ( 2016, Jan, 11 )
+          , endDate = ( 2016, Jan, 12 )
           , location = "London, UK"
           , tags = [ English, Developers, UK, Agile, DotNet, General ]
           }
         , { name = "NDC London"
           , link = "http://ndc-london.com/"
-          , startDate = parseDate "2016-01-13"
-          , endDate = parseDate "2016-01-15"
+          , startDate = ( 2016, Jan, 13 )
+          , endDate = ( 2016, Jan, 15 )
           , location = "London, UK"
           , tags = [ English, Developers, UK, Agile, DotNet, General ]
           }
         , { name = "Internet of Things Milan"
           , link = "https://www.mongodb.com/events/internet-of-things-milan"
-          , startDate = parseDate "2016-01-14"
-          , endDate = parseDate "2016-01-14"
+          , startDate = ( 2016, Jan, 14 )
+          , endDate = ( 2016, Jan, 14 )
           , location = "Milan, Italy"
           , tags = [ English, Developers, Italy, MongoDB, BigData, InternetOfThings ]
           }
         , { name = "GR8Conf IN"
           , link = "http://gr8conf.in/"
-          , startDate = parseDate "2016-01-16"
-          , endDate = parseDate "2016-01-16"
+          , startDate = ( 2016, Jan, 16 )
+          , endDate = ( 2016, Jan, 16 )
           , location = "New Delhi, India"
           , tags = [ English, Developers, India, Java, Groovy, Grails, Gradle ]
           }
         , { name = "O'Reilly Design Conference"
           , link = "http://conferences.oreilly.com/design/ux-interaction-iot-us"
-          , startDate = parseDate "2016-01-20"
-          , endDate = parseDate "2016-01-22"
+          , startDate = ( 2016, Jan, 20 )
+          , endDate = ( 2016, Jan, 22 )
           , location = "San Francisco, CA"
           , tags = [ English, Developers, USA, UX ]
           }
         , { name = "SVG Summit"
           , link = "http://environmentsforhumans.com/2016/svg-summit/"
-          , startDate = parseDate "2016-01-21"
-          , endDate = parseDate "2016-01-21"
+          , startDate = ( 2016, Jan, 21 )
+          , endDate = ( 2016, Jan, 21 )
           , location = "Remote"
           , tags = [ English, Designers, Developers, Remote, SVG ]
           }
         , { name = "PhoneGap Day"
           , link = "http://pgday.phonegap.com/us2016/"
-          , startDate = parseDate "2016-01-28"
-          , endDate = parseDate "2016-01-28"
+          , startDate = ( 2016, Jan, 28 )
+          , endDate = ( 2016, Jan, 28 )
           , location = "Lehi, UT"
           , tags = [ English, Developers, USA, PhoneGap, Mobile ]
           }
         , { name = "/dev/winter"
           , link = "http://devcycles.net/2016/winter/"
-          , startDate = parseDate "2016-01-23"
-          , endDate = parseDate "2016-01-23"
+          , startDate = ( 2016, Jan, 23 )
+          , endDate = ( 2016, Jan, 23 )
           , location = "Cambridge, UK"
           , tags = [ English, Developers, UK, DevOps, NoSQL, FunctionalProgramming ]
           }
         , { name = "dotSwift"
           , link = "http://www.dotswift.io/"
-          , startDate = parseDate "2016-01-29"
-          , endDate = parseDate "2016-01-29"
+          , startDate = ( 2016, Jan, 29 )
+          , endDate = ( 2016, Jan, 29 )
           , location = "Paris, France"
           , tags = [ English, Developers, France, Swift ]
           }
         , { name = "PHPBenelux"
           , link = "http://conference.phpbenelux.eu/2016/"
-          , startDate = parseDate "2016-01-29"
-          , endDate = parseDate "2016-01-30"
+          , startDate = ( 2016, Jan, 29 )
+          , endDate = ( 2016, Jan, 30 )
           , location = "Antwerp, Belgium"
           , tags = [ English, Developers, Belgium, PHP ]
           }
         , { name = "AlterConf D.C."
           , link = "http://www.alterconf.com/sessions/washington-dc"
-          , startDate = parseDate "2016-01-30"
-          , endDate = parseDate "2016-01-30"
+          , startDate = ( 2016, Jan, 30 )
+          , endDate = ( 2016, Jan, 30 )
           , location = "Washington, DC"
           , tags = [ English, Designers, Developers, USA, Diversity, SoftSkills ]
           }
         , { name = "FOSDEM"
           , link = "https://fosdem.org/2016/"
-          , startDate = parseDate "2016-01-30"
-          , endDate = parseDate "2016-01-31"
+          , startDate = ( 2016, Jan, 30 )
+          , endDate = ( 2016, Jan, 31 )
           , location = "Brussels, Belgium"
           , tags = [ English, Developers, Belgium, OpenSource, General ]
           }
         , { name = "PgConf.Russia"
           , link = "https://pgconf.ru/"
-          , startDate = parseDate "2016-02-03"
-          , endDate = parseDate "2016-02-05"
+          , startDate = ( 2016, Feb, 3 )
+          , endDate = ( 2016, Feb, 5 )
           , location = "Moscow, Russia"
           , tags = [ English, Russian, Developers, Russia, PostgreSQL ]
           }
         , { name = "UX/DEV Summit"
           , link = "http://uxdsummit.com/"
-          , startDate = parseDate "2016-02-04"
-          , endDate = parseDate "2016-02-06"
+          , startDate = ( 2016, Feb, 4 )
+          , endDate = ( 2016, Feb, 6 )
           , location = "Fort Lauderdale, FL"
           , tags = [ English, Designers, Developers, USA, UX, AngularJS, Ember, React ]
           }
         , { name = "Compose 2016"
           , link = "http://www.composeconference.org/"
-          , startDate = parseDate "2016-02-04"
-          , endDate = parseDate "2016-02-05"
+          , startDate = ( 2016, Feb, 4 )
+          , endDate = ( 2016, Feb, 5 )
           , location = "Brooklyn, NY"
           , tags = [ English, Developers, USA, FunctionalProgramming, Haskell, FSharp, OCaml, SML ]
           }
         , { name = "RubyFuza"
           , link = "http://www.rubyfuza.org/"
-          , startDate = parseDate "2016-02-04"
-          , endDate = parseDate "2016-02-05"
+          , startDate = ( 2016, Feb, 4 )
+          , endDate = ( 2016, Feb, 5 )
           , location = "Cape Town, South Africa"
           , tags = [ English, Developers, SouthAfrica, Ruby ]
           }
         , { name = "SunshinePHP"
           , link = "http://2016.sunshinephp.com/"
-          , startDate = parseDate "2016-02-04"
-          , endDate = parseDate "2016-02-06"
+          , startDate = ( 2016, Feb, 4 )
+          , endDate = ( 2016, Feb, 6 )
           , location = "Miami, FL"
           , tags = [ English, Developers, USA, PHP ]
           }
         , { name = "The Microservices Conference"
           , link = "http://microxchg.io/2016/"
-          , startDate = parseDate "2016-02-04"
-          , endDate = parseDate "2016-02-05"
+          , startDate = ( 2016, Feb, 4 )
+          , endDate = ( 2016, Feb, 5 )
           , location = "Berlin, Germany"
           , tags = [ English, Developers, Germany, Microservices ]
           }
         , { name = "JSConf Beirut"
           , link = "http://www.jsconfbeirut.com/"
-          , startDate = parseDate "2016-02-06"
-          , endDate = parseDate "2016-02-07"
+          , startDate = ( 2016, Feb, 6 )
+          , endDate = ( 2016, Feb, 7 )
           , location = "Beirut, Lebanon"
           , tags = [ English, Developers, Lebanon, JavaScript ]
           }
         , { name = "Forward JS Workshops"
           , link = "http://forwardjs.com/home"
-          , startDate = parseDate "2016-02-08"
-          , endDate = parseDate "2016-02-09"
+          , startDate = ( 2016, Feb, 8 )
+          , endDate = ( 2016, Feb, 9 )
           , location = "San Francisco, CA"
           , tags = [ English, Developers, USA, JavaScript, AngularJS, React, NodeJS ]
           }
         , { name = "Jfokus"
           , link = "http://www.jfokus.se/jfokus/"
-          , startDate = parseDate "2016-02-08"
-          , endDate = parseDate "2016-02-10"
+          , startDate = ( 2016, Feb, 8 )
+          , endDate = ( 2016, Feb, 10 )
           , location = "Stockholm, Sweden"
           , tags = [ English, Developers, Sweden, Java, General ]
           }
         , { name = "Jfokus IoT"
           , link = "http://www.jfokus.se/iot/"
-          , startDate = parseDate "2016-02-08"
-          , endDate = parseDate "2016-02-10"
+          , startDate = ( 2016, Feb, 8 )
+          , endDate = ( 2016, Feb, 10 )
           , location = "Stockholm, Sweden"
           , tags = [ English, Developers, Sweden, InternetOfThings ]
           }
         , { name = "Webstock"
           , link = "http://www.webstock.org.nz/16/"
-          , startDate = parseDate "2016-02-09"
-          , endDate = parseDate "2016-02-12"
+          , startDate = ( 2016, Feb, 9 )
+          , endDate = ( 2016, Feb, 12 )
           , location = "Wellington, New Zealand"
           , tags = [ English, Designers, Developers, NewZealand, General ]
           }
         , { name = "Forward JS"
           , link = "http://forwardjs.com/home"
-          , startDate = parseDate "2016-02-10"
-          , endDate = parseDate "2016-02-10"
+          , startDate = ( 2016, Feb, 10 )
+          , endDate = ( 2016, Feb, 10 )
           , location = "San Francisco, CA"
           , tags = [ English, Developers, USA, JavaScript, AngularJS, React, NodeJS ]
           }
         , { name = "RubyConf Australia"
           , link = "http://www.rubyconf.org.au/2016"
-          , startDate = parseDate "2016-02-10"
-          , endDate = parseDate "2016-02-13"
+          , startDate = ( 2016, Feb, 10 )
+          , endDate = ( 2016, Feb, 13 )
           , location = "Gold Coast, Australia"
           , tags = [ English, Developers, Australia, Ruby ]
           }
         , { name = "Clojure Remote"
           , link = "http://clojureremote.com/"
-          , startDate = parseDate "2016-02-11"
-          , endDate = parseDate "2016-02-12"
+          , startDate = ( 2016, Feb, 11 )
+          , endDate = ( 2016, Feb, 12 )
           , location = "Remote"
           , tags = [ English, Developers, Remote, Clojure, FunctionalProgramming ]
           }
         , { name = "Forward JS Workshops"
           , link = "http://forwardjs.com/home"
-          , startDate = parseDate "2016-02-11"
-          , endDate = parseDate "2016-02-13"
+          , startDate = ( 2016, Feb, 11 )
+          , endDate = ( 2016, Feb, 13 )
           , location = "San Francisco, CA"
           , tags = [ English, Developers, USA, JavaScript, AngularJS, React, NodeJS ]
           }
         , { name = "DevNexus"
           , link = "http://devnexus.com/s/index"
-          , startDate = parseDate "2016-02-15"
-          , endDate = parseDate "2016-02-17"
+          , startDate = ( 2016, Feb, 15 )
+          , endDate = ( 2016, Feb, 17 )
           , location = "Atlanta, GA"
           , tags = [ English, Developers, USA, Agile, BigData, Java, JavaScript, General ]
           }
         , { name = "Elastic{ON}"
           , link = "https://www.elastic.co/elasticon"
-          , startDate = parseDate "2016-02-17"
-          , endDate = parseDate "2016-02-19"
+          , startDate = ( 2016, Feb, 17 )
+          , endDate = ( 2016, Feb, 19 )
           , location = "San Francisco, CA"
           , tags = [ English, Developers, USA, MongoDB, BigData, Elasticserch, Logstash ]
           }
         , { name = "DrupalCon Asia"
           , link = "https://events.drupal.org/asia2016"
-          , startDate = parseDate "2016-02-18"
-          , endDate = parseDate "2016-02-21"
+          , startDate = ( 2016, Feb, 18 )
+          , endDate = ( 2016, Feb, 21 )
           , location = "Mumbai, India"
           , tags = [ English, Developers, India, Drupal, PHP ]
           }
         , { name = "Lambda Days"
           , link = "http://www.lambdadays.org/"
-          , startDate = parseDate "2016-02-18"
-          , endDate = parseDate "2016-02-19"
+          , startDate = ( 2016, Feb, 18 )
+          , endDate = ( 2016, Feb, 19 )
           , location = "Krakow, Poland"
           , tags = [ English, Developers, Poland, FunctionalProgramming, Erlang ]
           }
         , { name = "BOB 2016"
           , link = "http://bobkonf.de/2016/en/"
-          , startDate = parseDate "2016-02-19"
-          , endDate = parseDate "2016-02-19"
+          , startDate = ( 2016, Feb, 19 )
+          , endDate = ( 2016, Feb, 19 )
           , location = "Berlin, Germany"
           , tags = [ English, German, Developers, Germany, FunctionalProgramming, Clojure, Haskell, Scala, Erlang ]
           }
         , { name = "GopherCon India"
           , link = "http://www.gophercon.in/"
-          , startDate = parseDate "2016-02-19"
-          , endDate = parseDate "2016-02-10"
+          , startDate = ( 2016, Feb, 19 )
+          , endDate = ( 2016, Feb, 10 )
           , location = "Bengaluru, India"
           , tags = [ English, Developers, India, Go ]
           }
         , { name = "Bulgario Web Summit"
           , link = "http://bulgariawebsummit.com/"
-          , startDate = parseDate "2016-02-20"
-          , endDate = parseDate "2016-02-20"
+          , startDate = ( 2016, Feb, 20 )
+          , endDate = ( 2016, Feb, 20 )
           , location = "Sofia, Bulgaria"
           , tags = [ English, Designers, Developers, Bulgaria, UX, JavaScript, General ]
           }
         , { name = ":clojureD"
           , link = "http://www.clojured.de/"
-          , startDate = parseDate "2016-02-20"
-          , endDate = parseDate "2016-02-20"
+          , startDate = ( 2016, Feb, 20 )
+          , endDate = ( 2016, Feb, 20 )
           , location = "Berlin, Germany"
           , tags = [ English, Developers, Germany, FunctionalProgramming, Clojure ]
           }
         , { name = "The Rolling Scopes Conference"
           , link = "http://2016.conf.rollingscopes.com/"
-          , startDate = parseDate "2016-02-20"
-          , endDate = parseDate "2016-02-21"
+          , startDate = ( 2016, Feb, 20 )
+          , endDate = ( 2016, Feb, 21 )
           , location = "Minsk, Belarus"
           , tags = [ English, Russian, Developers, Belarus, CSS, NodeJS, JavaScript ]
           }
         , { name = "React.js Conf"
           , link = "http://conf.reactjs.com/"
-          , startDate = parseDate "2016-02-22"
-          , endDate = parseDate "2016-02-23"
+          , startDate = ( 2016, Feb, 22 )
+          , endDate = ( 2016, Feb, 23 )
           , location = "San Francisco, CA"
           , tags = [ English, Developers, USA, React, JavaScript ]
           }
         , { name = "GopherCon Dubai"
           , link = "http://www.gophercon.ae/"
-          , startDate = parseDate "2016-02-23"
-          , endDate = parseDate "2016-02-23"
+          , startDate = ( 2016, Feb, 23 )
+          , endDate = ( 2016, Feb, 23 )
           , location = "Dubai, UAE"
           , tags = [ English, Developers, UAE, Go ]
           }
         , { name = "ConFoo"
           , link = "http://confoo.ca/en"
-          , startDate = parseDate "2016-02-24"
-          , endDate = parseDate "2016-02-26"
+          , startDate = ( 2016, Feb, 24 )
+          , endDate = ( 2016, Feb, 26 )
           , location = "Montreal, QC, Canada"
           , tags = [ English, French, Developers, Canada, General ]
           }
         , { name = "UX Riga"
           , link = "http://www.uxriga.lv/"
-          , startDate = parseDate "2016-02-25"
-          , endDate = parseDate "2016-02-25"
+          , startDate = ( 2016, Feb, 25 )
+          , endDate = ( 2016, Feb, 25 )
           , location = "Riga, Latvia"
           , tags = [ English, Designers, Latvia, UX ]
           }
         , { name = "Interaction 16"
           , link = "http://interaction16.ixda.org/"
-          , startDate = parseDate "2016-03-01"
-          , endDate = parseDate "2016-03-04"
+          , startDate = ( 2016, Mar, 1 )
+          , endDate = ( 2016, Mar, 4 )
           , location = "Helsinki, Finland"
           , tags = [ English, Designers, Finland, UX ]
           }
         , { name = "try! Swift"
           , link = "http://www.tryswiftconf.com/en"
-          , startDate = parseDate "2016-03-02"
-          , endDate = parseDate "2016-03-04"
+          , startDate = ( 2016, Mar, 2 )
+          , endDate = ( 2016, Mar, 4 )
           , location = "Tokyo, Japan"
           , tags = [ English, Developers, Japan, Swift, IOS ]
           }
         , { name = "EnhanceConf"
           , link = "http://enhanceconf.com/"
-          , startDate = parseDate "2016-03-03"
-          , endDate = parseDate "2016-03-04"
+          , startDate = ( 2016, Mar, 3 )
+          , endDate = ( 2016, Mar, 4 )
           , location = "London, UK"
           , tags = [ English, Developers, UK, CSS, JavaScript, ProgressiveEnhancement ]
           }
         , { name = "Big Data Paris"
           , link = "http://www.bigdataparis.com/"
-          , startDate = parseDate "2016-03-07"
-          , endDate = parseDate "2016-03-08"
+          , startDate = ( 2016, Mar, 7 )
+          , endDate = ( 2016, Mar, 8 )
           , location = "Paris, France"
           , tags = [ French, Developers, France, MongoDB, BigData ]
           }
         , { name = "Erlang Factory SF Workshops"
           , link = "http://www.erlang-factory.com/sfbay2016/home"
-          , startDate = parseDate "2016-03-07"
-          , endDate = parseDate "2016-03-09"
+          , startDate = ( 2016, Mar, 7 )
+          , endDate = ( 2016, Mar, 9 )
           , location = "San Francisco, CA"
           , tags = [ English, Developers, USA, Erlang ]
           }
         , { name = "Fluent Conf Trainings"
           , link = "http://conferences.oreilly.com/fluent/javascript-html-us"
-          , startDate = parseDate "2016-03-07"
-          , endDate = parseDate "2016-03-08"
+          , startDate = ( 2016, Mar, 7 )
+          , endDate = ( 2016, Mar, 8 )
           , location = "San Francisco, CA"
           , tags = [ English, Designers, Developers, USA, CSS, JavaScript, UX, React, AngularJS, Docker ]
           }
         , { name = "QCon London"
           , link = "http://qconlondon.com/"
-          , startDate = parseDate "2016-03-07"
-          , endDate = parseDate "2016-03-09"
+          , startDate = ( 2016, Mar, 7 )
+          , endDate = ( 2016, Mar, 9 )
           , location = "London, UK"
           , tags = [ English, Developers, UK, General ]
           }
         , { name = "Fluent Conf"
           , link = "http://conferences.oreilly.com/fluent/javascript-html-us"
-          , startDate = parseDate "2016-03-08"
-          , endDate = parseDate "2016-03-10"
+          , startDate = ( 2016, Mar, 8 )
+          , endDate = ( 2016, Mar, 10 )
           , location = "San Francisco, CA"
           , tags = [ English, Designers, Developers, USA, CSS, JavaScript, UX, React, AngularJS, Docker ]
           }
         , { name = "jDays"
           , link = "http://www.jdays.se/"
-          , startDate = parseDate "2016-03-08"
-          , endDate = parseDate "2016-03-09"
+          , startDate = ( 2016, Mar, 8 )
+          , endDate = ( 2016, Mar, 9 )
           , location = "Gothenburg, Sweden"
           , tags = [ English, Developers, Sweden, Java ]
           }
         , { name = "SoCraTes ES"
           , link = "http://www.socrates-conference.es/doku.php"
-          , startDate = parseDate "2016-03-10"
-          , endDate = parseDate "2016-03-13"
+          , startDate = ( 2016, Mar, 10 )
+          , endDate = ( 2016, Mar, 13 )
           , location = "Gran Canaria, Spain"
           , tags = [ English, Developers, Spain, SoftwareCraftsmanship ]
           }
         , { name = "Erlang Factory SF"
           , link = "http://www.erlang-factory.com/sfbay2016/home"
-          , startDate = parseDate "2016-03-10"
-          , endDate = parseDate "2016-03-11"
+          , startDate = ( 2016, Mar, 10 )
+          , endDate = ( 2016, Mar, 11 )
           , location = "San Francisco, CA"
           , tags = [ English, Developers, USA, Erlang ]
           }
         , { name = "QCon London Tutorials"
           , link = "http://qconlondon.com/"
-          , startDate = parseDate "2016-03-10"
-          , endDate = parseDate "2016-03-11"
+          , startDate = ( 2016, Mar, 10 )
+          , endDate = ( 2016, Mar, 11 )
           , location = "London, UK"
           , tags = [ English, Developers, UK, General ]
           }
         , { name = "ScaleConf"
           , link = "http://scaleconf.org/"
-          , startDate = parseDate "2016-03-10"
-          , endDate = parseDate "2016-03-11"
+          , startDate = ( 2016, Mar, 10 )
+          , endDate = ( 2016, Mar, 11 )
           , location = "Cape Town, South Africa"
           , tags = [ English, Developers, SouthAfrica, Scalability ]
           }
         , { name = "Frontier Conf"
           , link = "https://www.frontierconf.com/"
-          , startDate = parseDate "2016-03-11"
-          , endDate = parseDate "2016-03-11"
+          , startDate = ( 2016, Mar, 11 )
+          , endDate = ( 2016, Mar, 11 )
           , location = "London, UK"
           , tags = [ English, Designers, UK, CSS, UX ]
           }
         , { name = "RWDevCon 2016"
           , link = "http://rwdevcon.com/"
-          , startDate = parseDate "2016-03-11"
-          , endDate = parseDate "2016-03-12"
+          , startDate = ( 2016, Mar, 11 )
+          , endDate = ( 2016, Mar, 12 )
           , location = "Alexandria, VA"
           , tags = [ English, Developers, USA, IOS, Swift ]
           }
         , { name = "Bath Ruby"
           , link = "http://bathruby.us1.list-manage1.com/subscribe?u=f18bb7508370614edaffb50dd&id=73743da027"
-          , startDate = parseDate "2016-03-11"
-          , endDate = parseDate "2016-03-11"
+          , startDate = ( 2016, Mar, 11 )
+          , endDate = ( 2016, Mar, 11 )
           , location = "Bath, UK"
           , tags = [ English, Developers, UK, Ruby ]
           }
         , { name = "wroc_love.rb"
           , link = "http://www.wrocloverb.com/"
-          , startDate = parseDate "2016-03-11"
-          , endDate = parseDate "2016-03-13"
+          , startDate = ( 2016, Mar, 11 )
+          , endDate = ( 2016, Mar, 13 )
           , location = "Wroclaw, Poland"
           , tags = [ English, Developers, Poland, Ruby ]
           }
         , { name = "An Event Apart Nashville"
           , link = "http://aneventapart.com/event/nashville-2016"
-          , startDate = parseDate "2016-03-14"
-          , endDate = parseDate "2016-03-16"
+          , startDate = ( 2016, Mar, 14 )
+          , endDate = ( 2016, Mar, 16 )
           , location = "Nashville, TN"
           , tags = [ English, Designers, Developers, USA, UX ]
           }
         , { name = "Erlang Factory SF Workshops"
           , link = "http://www.erlang-factory.com/sfbay2016/home"
-          , startDate = parseDate "2016-03-14"
-          , endDate = parseDate "2016-03-16"
+          , startDate = ( 2016, Mar, 14 )
+          , endDate = ( 2016, Mar, 16 )
           , location = "San Francisco, CA"
           , tags = [ English, Developers, USA, Erlang ]
           }
         , { name = "Smashing Conf"
           , link = "http://smashingconf.com/"
-          , startDate = parseDate "2016-03-15"
-          , endDate = parseDate "2016-03-16"
+          , startDate = ( 2016, Mar, 15 )
+          , endDate = ( 2016, Mar, 16 )
           , location = "Oxford, UK"
           , tags = [ English, Designers, UK, UX ]
           }
         , { name = "droidcon San Francisco"
           , link = "http://sf.droidcon.com/"
-          , startDate = parseDate "2016-03-17"
-          , endDate = parseDate "2016-03-18"
+          , startDate = ( 2016, Mar, 17 )
+          , endDate = ( 2016, Mar, 18 )
           , location = "San Francisco, CA"
           , tags = [ English, Developers, USA, Android, Mobile ]
           }
         , { name = "mdevcon"
           , link = "http://mdevcon.com/"
-          , startDate = parseDate "2016-03-17"
-          , endDate = parseDate "2016-03-18"
+          , startDate = ( 2016, Mar, 17 )
+          , endDate = ( 2016, Mar, 18 )
           , location = "Amsterdam, Netherlands"
           , tags = [ English, Developers, Netherlands, Mobile, IOS, Android ]
           }
         , { name = "Nordic PGDay"
           , link = "http://2016.nordicpgday.org/"
-          , startDate = parseDate "2016-03-17"
-          , endDate = parseDate "2016-03-17"
+          , startDate = ( 2016, Mar, 17 )
+          , endDate = ( 2016, Mar, 17 )
           , location = "Helsinki, Finland"
           , tags = [ English, Developers, Finland, PostgreSQL ]
           }
         , { name = "pgDay Asia"
           , link = "http://2016.pgday.asia/"
-          , startDate = parseDate "2016-03-17"
-          , endDate = parseDate "2016-03-19"
+          , startDate = ( 2016, Mar, 17 )
+          , endDate = ( 2016, Mar, 19 )
           , location = "Singapore"
           , tags = [ English, Developers, Singapore, PostgreSQL ]
           }
         , { name = "Scale Summit"
           , link = "http://www.scalesummit.org/"
-          , startDate = parseDate "2016-03-18"
-          , endDate = parseDate "2016-03-18"
+          , startDate = ( 2016, Mar, 18 )
+          , endDate = ( 2016, Mar, 18 )
           , location = "London, UK"
           , tags = [ English, Developers, UK, Scalability ]
           }
         , { name = "RubyConf India"
           , link = "http://rubyconfindia.org/"
-          , startDate = parseDate "2016-03-19"
-          , endDate = parseDate "2016-03-20"
+          , startDate = ( 2016, Mar, 19 )
+          , endDate = ( 2016, Mar, 20 )
           , location = "Kochi, India"
           , tags = [ English, Developers, India, Ruby ]
           }
         , { name = "MountainWest RubyConf"
           , link = "http://mtnwestrubyconf.org/2016/"
-          , startDate = parseDate "2016-03-21"
-          , endDate = parseDate "2016-03-22"
+          , startDate = ( 2016, Mar, 21 )
+          , endDate = ( 2016, Mar, 22 )
           , location = "Salt Lake City, UT"
           , tags = [ English, Developers, USA, Ruby ]
           }
         , { name = "CSS Day"
           , link = "http://2016.cssday.it/"
-          , startDate = parseDate "2016-03-25"
-          , endDate = parseDate "2016-03-25"
+          , startDate = ( 2016, Mar, 25 )
+          , endDate = ( 2016, Mar, 25 )
           , location = "Faenza, Italy"
           , tags = [ Italian, Designers, Italy, CSS ]
           }
         , { name = "DevExperience"
           , link = "http://devexperience.ro/"
-          , startDate = parseDate "2016-03-25"
-          , endDate = parseDate "2016-03-25"
+          , startDate = ( 2016, Mar, 25 )
+          , endDate = ( 2016, Mar, 25 )
           , location = "Lasi, Romania"
           , tags = [ English, Developers, Romania, General ]
           }
         , { name = "CocoaConf Chicago"
           , link = "http://cocoaconf.com/chicago-2016/home"
-          , startDate = parseDate "2016-03-25"
-          , endDate = parseDate "2016-03-26"
+          , startDate = ( 2016, Mar, 25 )
+          , endDate = ( 2016, Mar, 26 )
           , location = "Chicago, IL"
           , tags = [ English, Developers, USA, Cocoa, IOS ]
           }
         , { name = "Space City JS"
           , link = "http://spacecity.codes/"
-          , startDate = parseDate "2016-03-26"
-          , endDate = parseDate "2016-03-26"
+          , startDate = ( 2016, Mar, 26 )
+          , endDate = ( 2016, Mar, 26 )
           , location = "Houston, TX"
           , tags = [ English, Developers, USA, JavaScript ]
           }
         , { name = "EmberConf"
           , link = "http://emberconf.com/"
-          , startDate = parseDate "2016-03-29"
-          , endDate = parseDate "2016-03-30"
+          , startDate = ( 2016, Mar, 29 )
+          , endDate = ( 2016, Mar, 30 )
           , location = "Portland, OR"
           , tags = [ English, Developers, USA, Ember ]
           }
         , { name = "Clarity Conf"
           , link = "http://clarityconf.com/"
-          , startDate = parseDate "2016-03-31"
-          , endDate = parseDate "2016-04-01"
+          , startDate = ( 2016, Mar, 31 )
+          , endDate = ( 2016, Apr, 1 )
           , location = "San Francisco, CA"
           , tags = [ English, Designers, USA, UX ]
           }
         , { name = "Ruby on Ales"
           , link = "https://ruby.onales.com/"
-          , startDate = parseDate "2016-03-31"
-          , endDate = parseDate "2016-04-01"
+          , startDate = ( 2016, Mar, 31 )
+          , endDate = ( 2016, Apr, 1 )
           , location = "Bend, OR"
           , tags = [ English, Developers, USA, Ruby ]
           }
         , { name = "Fronteers Spring Thing"
           , link = "https://fronteers.nl/spring"
-          , startDate = parseDate "2016-04-01"
-          , endDate = parseDate "2016-04-01"
+          , startDate = ( 2016, Apr, 1 )
+          , endDate = ( 2016, Apr, 1 )
           , location = "Amsterdam, Netherlands"
           , tags = [ English, Developers, Netherlands, JavaScript ]
           }
         , { name = "An Event Apart Seattle"
           , link = "http://aneventapart.com/event/seattle-2016"
-          , startDate = parseDate "2016-04-04"
-          , endDate = parseDate "2016-04-06"
+          , startDate = ( 2016, Apr, 4 )
+          , endDate = ( 2016, Apr, 6 )
           , location = "Seattle, WA"
           , tags = [ English, Designers, Developers, USA, UX ]
           }
         , { name = "Smashing Conf SF"
           , link = "http://smashingconf.com/sf-2016/"
-          , startDate = parseDate "2016-04-05"
-          , endDate = parseDate "2016-04-06"
+          , startDate = ( 2016, Apr, 5 )
+          , endDate = ( 2016, Apr, 6 )
           , location = "San Francisco, CA"
           , tags = [ English, Designers, USA, UX ]
           }
         , { name = "Ancient City Ruby"
           , link = "http://www.ancientcityruby.com/"
-          , startDate = parseDate "2016-04-06"
-          , endDate = parseDate "2016-04-08"
+          , startDate = ( 2016, Apr, 6 )
+          , endDate = ( 2016, Apr, 8 )
           , location = "St. Augustine, FL"
           , tags = [ English, Developers, USA, Ruby ]
           }
         , { name = "AlterConf Minneapolis"
           , link = "http://www.alterconf.com/sessions/minneapolis-mn"
-          , startDate = parseDate "2016-04-09"
-          , endDate = parseDate "2016-04-09"
+          , startDate = ( 2016, Apr, 9 )
+          , endDate = ( 2016, Apr, 9 )
           , location = "Minneapolis, MN"
           , tags = [ English, Designers, Developers, USA, Diversity, SoftSkills ]
           }
         , { name = "RubyConf Philippines"
           , link = "http://rubyconf.ph/"
-          , startDate = parseDate "2016-04-07"
-          , endDate = parseDate "2016-04-09"
+          , startDate = ( 2016, Apr, 7 )
+          , endDate = ( 2016, Apr, 9 )
           , location = "Taguig, Philippines"
           , tags = [ English, Developers, Philippines, Ruby ]
           }
         , { name = "Greach"
           , link = "http://greachconf.com/"
-          , startDate = parseDate "2016-04-08"
-          , endDate = parseDate "2016-04-09"
+          , startDate = ( 2016, Apr, 8 )
+          , endDate = ( 2016, Apr, 9 )
           , location = "Madrid, Spain"
           , tags = [ English, Developers, Spain, Java, Groovy, Grails, Gradle ]
           }
         , { name = "MobCon"
           , link = "http://mobcon.com/mobcon-europe/"
-          , startDate = parseDate "2016-04-10"
-          , endDate = parseDate "2016-04-10"
+          , startDate = ( 2016, Apr, 10 )
+          , endDate = ( 2016, Apr, 10 )
           , location = "Sofia, Bulgaria"
           , tags = [ English, Developers, Bulgaria, Mobile, IOS, Android ]
           }
         , { name = "Yggdrasil"
           , link = "http://yggdrasilkonferansen.no/"
-          , startDate = parseDate "2016-04-11"
-          , endDate = parseDate "2016-04-12"
+          , startDate = ( 2016, Apr, 11 )
+          , endDate = ( 2016, Apr, 12 )
           , location = "Sandefjord, Norway"
           , tags = [ Norwegian, Designers, Norway, UX ]
           }
         , { name = "Converge SE"
           , link = "http://convergese.com/"
-          , startDate = parseDate "2016-04-13"
-          , endDate = parseDate "2016-04-15"
+          , startDate = ( 2016, Apr, 13 )
+          , endDate = ( 2016, Apr, 15 )
           , location = "Columbia, SC"
           , tags = [ English, Designers, Developers, USA, General ]
           }
         , { name = "Hadoop Summit Europe"
           , link = "http://2016.hadoopsummit.org/dublin/"
-          , startDate = parseDate "2016-04-13"
-          , endDate = parseDate "2016-04-14"
+          , startDate = ( 2016, Apr, 13 )
+          , endDate = ( 2016, Apr, 14 )
           , location = "Dublin, Ireland"
           , tags = [ English, Developers, Ireland, Hadoop, BigData, InternetOfThings ]
           }
         , { name = "ACE! Conference"
           , link = "http://aceconf.com/"
-          , startDate = parseDate "2016-04-14"
-          , endDate = parseDate "2016-04-15"
+          , startDate = ( 2016, Apr, 14 )
+          , endDate = ( 2016, Apr, 15 )
           , location = "Krakow, Poland"
           , tags = [ English, Developers, Poland, Agile, SoftwareCraftsmanship ]
           }
         , { name = "Clojure/west"
           , link = "http://clojurewest.org/"
-          , startDate = parseDate "2016-04-15"
-          , endDate = parseDate "2016-04-16"
+          , startDate = ( 2016, Apr, 15 )
+          , endDate = ( 2016, Apr, 16 )
           , location = "Seattle, WA"
           , tags = [ English, Developers, USA, Clojure, FunctionalProgramming ]
           }
         , { name = "CocoaConf Austin"
           , link = "http://cocoaconf.com/austin-2016/home"
-          , startDate = parseDate "2016-04-15"
-          , endDate = parseDate "2016-04-16"
+          , startDate = ( 2016, Apr, 15 )
+          , endDate = ( 2016, Apr, 16 )
           , location = "Austin, TX"
           , tags = [ English, Developers, USA, Cocoa, IOS ]
           }
         , { name = "JSConf Uruguay"
           , link = "https://jsconf.uy/"
-          , startDate = parseDate "2016-04-15"
-          , endDate = parseDate "2016-04-16"
+          , startDate = ( 2016, Apr, 15 )
+          , endDate = ( 2016, Apr, 16 )
           , location = "Montevideo, Uruguay"
           , tags = [ English, Developers, Uruguay, JavaScript ]
           }
         , { name = "Scalar"
           , link = "http://scalar-conf.com/"
-          , startDate = parseDate "2016-04-16"
-          , endDate = parseDate "2016-04-16"
+          , startDate = ( 2016, Apr, 16 )
+          , endDate = ( 2016, Apr, 16 )
           , location = "Warsaw, Poland"
           , tags = [ English, Developers, Poland, Scala ]
           }
         , { name = "PGConf US"
           , link = "http://www.pgconf.us/2016/"
-          , startDate = parseDate "2016-04-18"
-          , endDate = parseDate "2016-04-20"
+          , startDate = ( 2016, Apr, 18 )
+          , endDate = ( 2016, Apr, 20 )
           , location = "New York, NY"
           , tags = [ English, Developers, USA, PostgreSQL ]
           }
         , { name = "ACCU"
           , link = "http://accu.org/index.php/conferences/accu_conference_2016"
-          , startDate = parseDate "2016-04-19"
-          , endDate = parseDate "2016-04-23"
+          , startDate = ( 2016, Apr, 19 )
+          , endDate = ( 2016, Apr, 23 )
           , location = "Bristol, UK"
           , tags = [ English, Developers, UK, General, CPlusPlus ]
           }
         , { name = "Industry Conf"
           , link = "http://2016.industryconf.com/"
-          , startDate = parseDate "2016-04-20"
-          , endDate = parseDate "2016-04-20"
+          , startDate = ( 2016, Apr, 20 )
+          , endDate = ( 2016, Apr, 20 )
           , location = "Newcastle, UK"
           , tags = [ English, Developers, UK, General ]
           }
         , { name = "CycleConf"
           , link = "https://twitter.com/cycleconf"
-          , startDate = parseDate "2016-04-21"
-          , endDate = parseDate "2016-04-24"
+          , startDate = ( 2016, Apr, 21 )
+          , endDate = ( 2016, Apr, 24 )
           , location = "Copenhagen, Denmark"
           , tags = [ English, Developers, Denmark, CycleJS, JavaScript ]
           }
         , { name = "MCE"
           , link = "http://mceconf.com/"
-          , startDate = parseDate "2016-04-21"
-          , endDate = parseDate "2016-04-22"
+          , startDate = ( 2016, Apr, 21 )
+          , endDate = ( 2016, Apr, 22 )
           , location = "Warsaw, Poland"
           , tags = [ English, Designers, Developers, Poland, Mobile ]
           }
         , { name = "Render Conf"
           , link = "http://2016.render-conf.com/"
-          , startDate = parseDate "2016-04-21"
-          , endDate = parseDate "2016-04-22"
+          , startDate = ( 2016, Apr, 21 )
+          , endDate = ( 2016, Apr, 22 )
           , location = "Oxford, UK"
           , tags = [ English, Designers, Developers, UK, CSS, JavaScript, UX ]
           }
         , { name = "dotSecurity"
           , link = "http://www.dotsecurity.io/"
-          , startDate = parseDate "2016-04-22"
-          , endDate = parseDate "2016-04-22"
+          , startDate = ( 2016, Apr, 22 )
+          , endDate = ( 2016, Apr, 22 )
           , location = "Paris, France"
           , tags = [ English, Developers, France, Security ]
           }
         , { name = "Generate NY"
           , link = "http://generateconf.com/new-york-2016"
-          , startDate = parseDate "2016-04-22"
-          , endDate = parseDate "2016-04-22"
+          , startDate = ( 2016, Apr, 22 )
+          , endDate = ( 2016, Apr, 22 )
           , location = "New York, NY"
           , tags = [ English, Designers, USA, UX ]
           }
         , { name = "Future of Web Design"
           , link = "https://futureofwebdesign.com/london-2016/"
-          , startDate = parseDate "2016-04-25"
-          , endDate = parseDate "2016-04-27"
+          , startDate = ( 2016, Apr, 25 )
+          , endDate = ( 2016, Apr, 27 )
           , location = "London, UK"
           , tags = [ English, Designers, UK, UX ]
           }
         , { name = "dotScale"
           , link = "http://www.dotscale.io/"
-          , startDate = parseDate "2016-04-25"
-          , endDate = parseDate "2016-04-25"
+          , startDate = ( 2016, Apr, 25 )
+          , endDate = ( 2016, Apr, 25 )
           , location = "Paris, France"
           , tags = [ English, Developers, France, Scalability ]
           }
         , { name = "OpenVis Conf"
           , link = "https://openvisconf.com/"
-          , startDate = parseDate "2016-04-25"
-          , endDate = parseDate "2016-04-26"
+          , startDate = ( 2016, Apr, 25 )
+          , endDate = ( 2016, Apr, 26 )
           , location = "Boston, MA"
           , tags = [ English, Developers, USA, DataVisualization ]
           }
         , { name = "Craft Conf"
           , link = "http://craft-conf.com/2016"
-          , startDate = parseDate "2016-04-26"
-          , endDate = parseDate "2016-04-29"
+          , startDate = ( 2016, Apr, 26 )
+          , endDate = ( 2016, Apr, 29 )
           , location = "Budapest, Hungary"
           , tags = [ English, Developers, Hungary, SoftwareCraftsmanship ]
           }
         , { name = "University of Illinois WebCon"
           , link = "http://webcon.illinois.edu/"
-          , startDate = parseDate "2016-04-27"
-          , endDate = parseDate "2016-04-28"
+          , startDate = ( 2016, Apr, 27 )
+          , endDate = ( 2016, Apr, 28 )
           , location = "Champaign, IL"
           , tags = [ English, Developers, USA, General ]
           }
         , { name = "YOW! Lambda Jam"
           , link = "http://lambdajam.yowconference.com.au/"
-          , startDate = parseDate "2016-04-28"
-          , endDate = parseDate "2016-04-29"
+          , startDate = ( 2016, Apr, 28 )
+          , endDate = ( 2016, Apr, 29 )
           , location = "Brisbane, Australia"
           , tags = [ English, Developers, Australia, FunctionalProgramming ]
           }
         , { name = "Future Insights Live"
           , link = "https://futureinsightslive.com/chicago-2016/"
-          , startDate = parseDate "2016-05-02"
-          , endDate = parseDate "2016-05-05"
+          , startDate = ( 2016, May, 2 )
+          , endDate = ( 2016, May, 5 )
           , location = "Chicago, IL"
           , tags = [ English, Designers, Developers, USA, UX, JavaScript, InternetOfThings ]
           }
         , { name = "Continuous Lifecycle London"
           , link = "http://continuouslifecycle.london/"
-          , startDate = parseDate "2016-05-03"
-          , endDate = parseDate "2016-05-05"
+          , startDate = ( 2016, May, 3 )
+          , endDate = ( 2016, May, 5 )
           , location = "London, UK"
           , tags = [ English, Developers, UK, DevOps ]
           }
         , { name = "YOW! West"
           , link = "http://west.yowconference.com.au/"
-          , startDate = parseDate "2016-05-03"
-          , endDate = parseDate "2016-05-04"
+          , startDate = ( 2016, May, 3 )
+          , endDate = ( 2016, May, 4 )
           , location = "Perth, Australia"
           , tags = [ English, Developers, Australia, General ]
           }
         , { name = "ng-conf"
           , link = "http://www.ng-conf.org/"
-          , startDate = parseDate "2016-05-04"
-          , endDate = parseDate "2016-05-06"
+          , startDate = ( 2016, May, 4 )
+          , endDate = ( 2016, May, 6 )
           , location = "Salt Lake City, UT"
           , tags = [ English, Developers, USA, JavaScript, AngularJS ]
           }
         , { name = "RailsConf"
           , link = "http://railsconf.com/"
-          , startDate = parseDate "2016-05-04"
-          , endDate = parseDate "2016-05-06"
+          , startDate = ( 2016, May, 4 )
+          , endDate = ( 2016, May, 6 )
           , location = "Kansas City, MO"
           , tags = [ English, Developers, USA, Ruby, Rails ]
           }
         , { name = "CocoaConf Seattle"
           , link = "http://cocoaconf.com/seattle-2016/home"
-          , startDate = parseDate "2016-05-06"
-          , endDate = parseDate "2016-05-07"
+          , startDate = ( 2016, May, 6 )
+          , endDate = ( 2016, May, 7 )
           , location = "Seattle, WA"
           , tags = [ English, Developers, USA, IOS, Cocoa ]
           }
         , { name = "SyntaxCon"
           , link = "http://2016.syntaxcon.com/"
-          , startDate = parseDate "2016-05-06"
-          , endDate = parseDate "2016-05-07"
+          , startDate = ( 2016, May, 6 )
+          , endDate = ( 2016, May, 7 )
           , location = "Charleston, SC"
           , tags = [ English, Developers, USA, General ]
           }
         , { name = "9th European Lisp Symposium"
           , link = "http://www.european-lisp-symposium.org/"
-          , startDate = parseDate "2016-05-09"
-          , endDate = parseDate "2016-05-10"
+          , startDate = ( 2016, May, 9 )
+          , endDate = ( 2016, May, 10 )
           , location = "Krakow, Poland"
           , tags = [ English, Developers, Poland, Lisp, Clojure ]
           }
         , { name = "C++Now"
           , link = "http://cppnow.org/"
-          , startDate = parseDate "2016-05-09"
-          , endDate = parseDate "2016-05-14"
+          , startDate = ( 2016, May, 9 )
+          , endDate = ( 2016, May, 14 )
           , location = "Aspen, CO"
           , tags = [ English, Developers, USA, CPlusPlus ]
           }
         , { name = "Apache: Big Data North America"
           , link = "http://www.apachecon.com/"
-          , startDate = parseDate "2016-05-09"
-          , endDate = parseDate "2016-05-11"
+          , startDate = ( 2016, May, 9 )
+          , endDate = ( 2016, May, 11 )
           , location = "Vancouver, BC, Canada"
           , tags = [ English, Developers, Canada, BigData ]
           }
         , { name = "Beyond Tellerrand"
           , link = "http://beyondtellerrand.com/events/duesseldorf-2016"
-          , startDate = parseDate "2016-05-09"
-          , endDate = parseDate "2016-05-11"
+          , startDate = ( 2016, May, 9 )
+          , endDate = ( 2016, May, 11 )
           , location = "Düsseldorf, Germany"
           , tags = [ English, Designers, Developers, Germany, UX, General ]
           }
         , { name = "ChefConf"
           , link = "https://www.chef.io/chefconf/"
-          , startDate = parseDate "2016-05-09"
-          , endDate = parseDate "2016-05-11"
+          , startDate = ( 2016, May, 9 )
+          , endDate = ( 2016, May, 11 )
           , location = "Austin, TX"
           , tags = [ English, Developers, USA, Chef, DevOps ]
           }
         , { name = "DrupalCon New Orleans"
           , link = "https://events.drupal.org/neworleans2016/"
-          , startDate = parseDate "2016-05-09"
-          , endDate = parseDate "2016-05-13"
+          , startDate = ( 2016, May, 9 )
+          , endDate = ( 2016, May, 13 )
           , location = "New Orleans, LA"
           , tags = [ English, Developers, USA, Drupal, PHP ]
           }
         , { name = "jsDay"
           , link = "http://2016.jsday.it/"
-          , startDate = parseDate "2016-05-11"
-          , endDate = parseDate "2016-05-12"
+          , startDate = ( 2016, May, 11 )
+          , endDate = ( 2016, May, 12 )
           , location = "Verona, Italy"
           , tags = [ English, Developers, Italy, JavaScript ]
           }
         , { name = "CSSConf Budapest"
           , link = "http://cssconfbp.rocks/"
-          , startDate = parseDate "2016-05-11"
-          , endDate = parseDate "2016-05-11"
+          , startDate = ( 2016, May, 11 )
+          , endDate = ( 2016, May, 11 )
           , location = "Budapest, Hungary"
           , tags = [ English, Designers, Hungary, CSS ]
           }
         , { name = "ApacheCon Core North America"
           , link = "http://www.apachecon.com/"
-          , startDate = parseDate "2016-05-12"
-          , endDate = parseDate "2016-05-13"
+          , startDate = ( 2016, May, 12 )
+          , endDate = ( 2016, May, 13 )
           , location = "Vancouver, Canada"
           , tags = [ English, Developers, Canada, OpenSource ]
           }
+        , { name = "Front Conference"
+          , link = "http://www.frontutah.com/"
+          , startDate = ( 2016, May, 12 )
+          , endDate = ( 2016, May, 13 )
+          , location = "Salt Lake City, UT"
+          , tags = [ English, Designers, USA, UX ]
+          }
         , { name = "JSConf Budapest"
           , link = "http://jsconfbp.com/"
-          , startDate = parseDate "2016-05-12"
-          , endDate = parseDate "2016-05-13"
+          , startDate = ( 2016, May, 12 )
+          , endDate = ( 2016, May, 13 )
           , location = "Budapest, Hungary"
           , tags = [ English, Developers, Hungary, JavaScript ]
           }
         , { name = "An Event Apart Boston"
           , link = "http://aneventapart.com/event/boston-2016"
-          , startDate = parseDate "2016-05-16"
-          , endDate = parseDate "2016-05-18"
+          , startDate = ( 2016, May, 16 )
+          , endDate = ( 2016, May, 18 )
           , location = "Boston, MA"
           , tags = [ English, Designers, Developers, USA, UX ]
           }
         , { name = "Open Source Convention Tutorials"
           , link = "http://conferences.oreilly.com/oscon/open-source"
-          , startDate = parseDate "2016-05-16"
-          , endDate = parseDate "2016-05-17"
+          , startDate = ( 2016, May, 16 )
+          , endDate = ( 2016, May, 17 )
           , location = "Austin, TX"
           , tags = [ English, Developers, USA, OpenSource ]
           }
         , { name = "Front-Trends"
           , link = "http://2016.front-trends.com/"
-          , startDate = parseDate "2016-05-18"
-          , endDate = parseDate "2016-05-20"
+          , startDate = ( 2016, May, 18 )
+          , endDate = ( 2016, May, 20 )
           , location = "Warsaw, Poland"
           , tags = [ English, Designers, Poland, UX ]
           }
         , { name = "Open Source Convention"
           , link = "http://conferences.oreilly.com/oscon/open-source"
-          , startDate = parseDate "2016-05-18"
-          , endDate = parseDate "2016-05-19"
+          , startDate = ( 2016, May, 18 )
+          , endDate = ( 2016, May, 19 )
           , location = "Austin, TX"
           , tags = [ English, Developers, USA, OpenSource ]
           }
         , { name = "PhoneGap Day EU"
           , link = "http://pgday.phonegap.com/eu2016/"
-          , startDate = parseDate "2016-05-19"
-          , endDate = parseDate "2016-05-20"
+          , startDate = ( 2016, May, 19 )
+          , endDate = ( 2016, May, 20 )
           , location = "Amsterdam, Netherlands"
           , tags = [ English, Developers, Netherlands, PhoneGap, Mobile ]
           }
         , { name = "self.conference"
           , link = "http://selfconference.org/"
-          , startDate = parseDate "2016-05-20"
-          , endDate = parseDate "2016-05-21"
+          , startDate = ( 2016, May, 20 )
+          , endDate = ( 2016, May, 21 )
           , location = "Detroit, MI"
           , tags = [ English, Designers, Developers, USA, General, SoftSkills ]
           }
         , { name = "UIKonf"
           , link = "http://www.uikonf.com/"
-          , startDate = parseDate "2016-05-22"
-          , endDate = parseDate "2016-05-25"
+          , startDate = ( 2016, May, 22 )
+          , endDate = ( 2016, May, 25 )
           , location = "Berlin, Germany"
           , tags = [ English, Developers, Germany, IOS ]
           }
         , { name = "php[tek]"
           , link = "https://tek.phparch.com/"
-          , startDate = parseDate "2016-05-23"
-          , endDate = parseDate "2016-05-27"
+          , startDate = ( 2016, May, 23 )
+          , endDate = ( 2016, May, 27 )
           , location = "St. Louis, MO"
           , tags = [ English, Developers, USA, PHP ]
           }
         , { name = "GOTO Chicago Workshops"
           , link = "http://gotocon.com/chicago-2016"
-          , startDate = parseDate "2016-05-23"
-          , endDate = parseDate "2016-05-23"
+          , startDate = ( 2016, May, 23 )
+          , endDate = ( 2016, May, 23 )
           , location = "Chicago, IL"
           , tags = [ English, Developers, USA, General ]
           }
         , { name = "GOTO Chicago"
           , link = "http://gotocon.com/chicago-2016"
-          , startDate = parseDate "2016-05-24"
-          , endDate = parseDate "2016-05-25"
+          , startDate = ( 2016, May, 24 )
+          , endDate = ( 2016, May, 25 )
           , location = "Chicago, IL"
           , tags = [ English, Developers, USA, General ]
           }
         , { name = "SIGNAL 2016"
           , link = "https://www.twilio.com/signal"
-          , startDate = parseDate "2016-05-24"
-          , endDate = parseDate "2016-05-25"
+          , startDate = ( 2016, May, 24 )
+          , endDate = ( 2016, May, 25 )
           , location = "San Francisco, CA"
           , tags = [ English, Developers, USA, Communications ]
           }
         , { name = "UXLx"
           , link = "https://www.ux-lx.com/"
-          , startDate = parseDate "2016-05-24"
-          , endDate = parseDate "2016-05-27"
+          , startDate = ( 2016, May, 24 )
+          , endDate = ( 2016, May, 27 )
           , location = "Lisbon, Portugal"
           , tags = [ English, Designers, Portugal, UX ]
           }
         , { name = "GlueCon"
           , link = "http://gluecon.com/"
-          , startDate = parseDate "2016-05-25"
-          , endDate = parseDate "2016-05-26"
+          , startDate = ( 2016, May, 25 )
+          , endDate = ( 2016, May, 26 )
           , location = "Broomfield, CO"
           , tags = [ English, Developers, USA, General, DevOps, BigData ]
           }
         , { name = "PureScript Conf"
           , link = "https://twitter.com/lambda_conf/status/667099897984712704"
-          , startDate = parseDate "2016-05-25"
-          , endDate = parseDate "2016-05-25"
+          , startDate = ( 2016, May, 25 )
+          , endDate = ( 2016, May, 25 )
           , location = "Boulder, CO"
           , tags = [ English, Developers, USA, FunctionalProgramming, PureScript ]
           }
         , { name = "GOTO Chicago Workshops"
           , link = "http://gotocon.com/chicago-2016"
-          , startDate = parseDate "2016-05-26"
-          , endDate = parseDate "2016-05-26"
+          , startDate = ( 2016, May, 26 )
+          , endDate = ( 2016, May, 26 )
           , location = "Chicago, IL"
           , tags = [ English, Developers, USA, General ]
           }
         , { name = "LambdaConf"
           , link = "http://lambdaconf.us/"
-          , startDate = parseDate "2016-05-26"
-          , endDate = parseDate "2016-05-29"
+          , startDate = ( 2016, May, 26 )
+          , endDate = ( 2016, May, 29 )
           , location = "Boulder, CO"
           , tags = [ English, Developers, USA, FunctionalProgramming, Haskell, Scala, PureScript ]
           }
         , { name = "Frontend United"
           , link = "http://frontendunited.org/"
-          , startDate = parseDate "2016-05-27"
-          , endDate = parseDate "2016-05-28"
+          , startDate = ( 2016, May, 27 )
+          , endDate = ( 2016, May, 28 )
           , location = "Ghent, Belgium"
           , tags = [ English, Designers, Developers, Belgium, UX, Drupal, PHP ]
           }
         , { name = "PyCon Tutorials"
           , link = "https://us.pycon.org/2016/"
-          , startDate = parseDate "2016-05-28"
-          , endDate = parseDate "2016-05-29"
+          , startDate = ( 2016, May, 28 )
+          , endDate = ( 2016, May, 29 )
           , location = "Portland, OR"
           , tags = [ English, Developers, USA, Python ]
           }
         , { name = "PyCon"
           , link = "https://us.pycon.org/2016/"
-          , startDate = parseDate "2016-05-30"
-          , endDate = parseDate "2016-06-01"
+          , startDate = ( 2016, May, 30 )
+          , endDate = ( 2016, Jun, 1 )
           , location = "Portland, OR"
           , tags = [ English, Developers, USA, Python ]
           }
         , { name = "MagmaConf"
           , link = "http://www.magmaconf.com/"
-          , startDate = parseDate "2016-06-01"
-          , endDate = parseDate "2016-06-03"
+          , startDate = ( 2016, Jun, 1 )
+          , endDate = ( 2016, Jun, 3 )
           , location = "Manzanillo, Mexico"
           , tags = [ English, Developers, Mexico, Ruby ]
           }
         , { name = "CSSConf Nordic"
           , link = "http://cssconf.no/"
-          , startDate = parseDate "2016-06-01"
-          , endDate = parseDate "2016-06-01"
+          , startDate = ( 2016, Jun, 1 )
+          , endDate = ( 2016, Jun, 1 )
           , location = "Oslo, Norway"
           , tags = [ English, Designers, Norway, UX, CSS ]
           }
         , { name = "GR8Conf EU"
           , link = "http://gr8conf.eu/"
-          , startDate = parseDate "2016-06-02"
-          , endDate = parseDate "2016-06-04"
+          , startDate = ( 2016, Jun, 2 )
+          , endDate = ( 2016, Jun, 4 )
           , location = "Copenhagen, Denmark"
           , tags = [ English, Developers, Denmark, Java, Groovy, Grails, Gradle ]
           }
         , { name = "PyCon Sprints"
           , link = "https://us.pycon.org/2016/"
-          , startDate = parseDate "2016-06-02"
-          , endDate = parseDate "2016-06-05"
+          , startDate = ( 2016, Jun, 2 )
+          , endDate = ( 2016, Jun, 5 )
           , location = "Portland, OR"
           , tags = [ English, Developers, USA, Python ]
           }
         , { name = "SoCraTes UK"
           , link = "http://socratesuk.org/"
-          , startDate = parseDate "2016-06-02"
-          , endDate = parseDate "2016-06-05"
+          , startDate = ( 2016, Jun, 2 )
+          , endDate = ( 2016, Jun, 5 )
           , location = "Dorking, UK"
           , tags = [ English, Developers, UK, SoftwareCraftsmanship ]
           }
         , { name = "ReactEurope"
           , link = "https://www.react-europe.org/"
-          , startDate = parseDate "2016-06-02"
-          , endDate = parseDate "2016-06-03"
+          , startDate = ( 2016, Jun, 2 )
+          , endDate = ( 2016, Jun, 3 )
           , location = "Paris, France"
           , tags = [ English, Developers, France, React, JavaScript ]
           }
         , { name = "Scotland JS"
           , link = "http://scotlandjs.com/"
-          , startDate = parseDate "2016-06-02"
-          , endDate = parseDate "2016-06-03"
+          , startDate = ( 2016, Jun, 2 )
+          , endDate = ( 2016, Jun, 3 )
           , location = "Edinburgh, Scotland"
           , tags = [ English, Developers, Scotland, JavaScript ]
           }
         , { name = "Web Rebels"
           , link = "https://www.webrebels.org/"
-          , startDate = parseDate "2016-06-02"
-          , endDate = parseDate "2016-06-03"
+          , startDate = ( 2016, Jun, 2 )
+          , endDate = ( 2016, Jun, 3 )
           , location = "Oslo, Norway"
           , tags = [ English, Developers, Norway, JavaScript ]
           }
         , { name = "Berlin Buzzwords"
           , link = "http://berlinbuzzwords.de/"
-          , startDate = parseDate "2016-06-05"
-          , endDate = parseDate "2016-06-07"
+          , startDate = ( 2016, Jun, 5 )
+          , endDate = ( 2016, Jun, 7 )
           , location = "Berlin, Germany"
           , tags = [ English, Developers, Germany, BigData ]
           }
         , { name = "NDC Oslo Workshops"
           , link = "http://ndcoslo.com/"
-          , startDate = parseDate "2016-06-06"
-          , endDate = parseDate "2016-06-07"
+          , startDate = ( 2016, Jun, 6 )
+          , endDate = ( 2016, Jun, 7 )
           , location = "Oslo, Norway"
           , tags = [ English, Developers, Norway, Agile, DotNet, General ]
           }
         , { name = "NDC Oslo"
           , link = "http://ndcoslo.com/"
-          , startDate = parseDate "2016-06-08"
-          , endDate = parseDate "2016-06-10"
+          , startDate = ( 2016, Jun, 8 )
+          , endDate = ( 2016, Jun, 10 )
           , location = "Oslo, Norway"
           , tags = [ English, Developers, Norway, Agile, DotNet, General ]
           }
         , { name = "UX Scotland"
           , link = "http://uxscotland.net/2016/"
-          , startDate = parseDate "2016-06-08"
-          , endDate = parseDate "2016-06-10"
+          , startDate = ( 2016, Jun, 8 )
+          , endDate = ( 2016, Jun, 10 )
           , location = "Edinburgh, Scotland"
           , tags = [ English, Designers, Scotland, UX ]
           }
         , { name = "QCon New York"
           , link = "https://qconnewyork.com/"
-          , startDate = parseDate "2016-06-13"
-          , endDate = parseDate "2016-06-15"
+          , startDate = ( 2016, Jun, 13 )
+          , endDate = ( 2016, Jun, 15 )
           , location = "New York, NY"
           , tags = [ English, Developers, USA, General ]
           }
         , { name = "GOTO Amsterdam Workshops"
           , link = "http://gotocon.com/amsterdam-2016/"
-          , startDate = parseDate "2016-06-13"
-          , endDate = parseDate "2016-06-13"
+          , startDate = ( 2016, Jun, 13 )
+          , endDate = ( 2016, Jun, 13 )
           , location = "Amsterdam, Netherlands"
           , tags = [ English, Developers, Netherlands, General ]
           }
         , { name = "GOTO Amsterdam"
           , link = "http://gotocon.com/amsterdam-2016/"
-          , startDate = parseDate "2016-06-14"
-          , endDate = parseDate "2016-06-15"
+          , startDate = ( 2016, Jun, 14 )
+          , endDate = ( 2016, Jun, 15 )
           , location = "Amsterdam, Netherlands"
           , tags = [ English, Developers, Netherlands, General ]
           }
         , { name = "Front End Design Conference"
           , link = "http://frontenddesignconference.com/"
-          , startDate = parseDate "2016-06-15"
-          , endDate = parseDate "2016-06-17"
+          , startDate = ( 2016, Jun, 15 )
+          , endDate = ( 2016, Jun, 17 )
           , location = "St. Petersburg, FL"
           , tags = [ English, Designers, USA, UX ]
           }
         , { name = "CSS Day"
           , link = "http://cssday.nl/2016"
-          , startDate = parseDate "2016-06-16"
-          , endDate = parseDate "2016-06-17"
+          , startDate = ( 2016, Jun, 16 )
+          , endDate = ( 2016, Jun, 17 )
           , location = "Amsterdam, Netherlands"
           , tags = [ English, Designers, Netherlands, CSS ]
           }
         , { name = "QCon New York Tutorials"
           , link = "https://qconnewyork.com/"
-          , startDate = parseDate "2016-06-16"
-          , endDate = parseDate "2016-06-17"
+          , startDate = ( 2016, Jun, 16 )
+          , endDate = ( 2016, Jun, 17 )
           , location = "New York, NY"
           , tags = [ English, Developers, USA, General ]
           }
         , { name = "DockerCon"
           , link = "http://2016.dockercon.com/"
-          , startDate = parseDate "2016-06-19"
-          , endDate = parseDate "2016-06-21"
+          , startDate = ( 2016, Jun, 19 )
+          , endDate = ( 2016, Jun, 21 )
           , location = "Seattle, WA"
           , tags = [ English, Developers, USA, Docker ]
           }
         , { name = "O'Reilly Velocity"
           , link = "http://conferences.oreilly.com/velocity/devops-web-performance-ca/"
-          , startDate = parseDate "2016-06-21"
-          , endDate = parseDate "2016-06-23"
+          , startDate = ( 2016, Jun, 21 )
+          , endDate = ( 2016, Jun, 23 )
           , location = "Santa Clara, CA"
           , tags = [ English, Developers, USA, Scalability, DevOps ]
           }
         , { name = "Web Design Day"
           , link = "http://webdesignday.com/"
-          , startDate = parseDate "2016-06-23"
-          , endDate = parseDate "2016-06-24"
+          , startDate = ( 2016, Jun, 23 )
+          , endDate = ( 2016, Jun, 24 )
           , location = "Pittsburgh, PA"
           , tags = [ English, Designers, USA, UX ]
           }
         , { name = "Dinosaur.js"
           , link = "http://dinosaurjs.org/"
-          , startDate = parseDate "2016-06-24"
-          , endDate = parseDate "2016-06-24"
+          , startDate = ( 2016, Jun, 24 )
+          , endDate = ( 2016, Jun, 24 )
           , location = "Denver, CO"
           , tags = [ English, Developers, USA, JavaScript ]
           }
         , { name = "GIANT Conf"
           , link = "http://www.giantux.com/conf2016/"
-          , startDate = parseDate "2016-06-27"
-          , endDate = parseDate "2016-06-29"
+          , startDate = ( 2016, Jun, 27 )
+          , endDate = ( 2016, Jun, 29 )
           , location = "TBD"
           , tags = [ English, Designers, USA, UX ]
           }
         , { name = "Hadoop Summit North America"
           , link = "http://2016.hadoopsummit.org/san-jose/"
-          , startDate = parseDate "2016-06-28"
-          , endDate = parseDate "2016-06-30"
+          , startDate = ( 2016, Jun, 28 )
+          , endDate = ( 2016, Jun, 30 )
           , location = "San Jose, CA"
           , tags = [ English, Developers, USA, Hadoop, BigData, InternetOfThings ]
           }
         , { name = "MongoDB World 2016"
           , link = "https://www.mongodb.com/world16"
-          , startDate = parseDate "2016-06-28"
-          , endDate = parseDate "2016-06-29"
+          , startDate = ( 2016, Jun, 28 )
+          , endDate = ( 2016, Jun, 29 )
           , location = "New York, NY"
           , tags = [ English, Developers, USA, MongoDB, BigData ]
           }
         , { name = "Brighton Ruby"
           , link = "http://brightonruby.com/"
-          , startDate = parseDate "2016-07-08"
-          , endDate = parseDate "2016-07-08"
+          , startDate = ( 2016, Jul, 8 )
+          , endDate = ( 2016, Jul, 8 )
           , location = "Brighton, UK"
           , tags = [ English, Developers, UK, Ruby ]
           }
         , { name = "Chef Conf"
           , link = "https://www.chef.io/chefconf/"
-          , startDate = parseDate "2016-07-11"
-          , endDate = parseDate "2016-07-13"
+          , startDate = ( 2016, Jul, 11 )
+          , endDate = ( 2016, Jul, 13 )
           , location = "Austin, TX"
           , tags = [ English, Developers, USA, Chef, DevOps ]
           }
         , { name = "GopherCon"
           , link = "https://www.gophercon.com/"
-          , startDate = parseDate "2016-07-11"
-          , endDate = parseDate "2016-07-13"
+          , startDate = ( 2016, Jul, 11 )
+          , endDate = ( 2016, Jul, 13 )
           , location = "Denver, CO"
           , tags = [ English, Developers, USA, Go ]
           }
         , { name = "EuroPython"
           , link = "http://ep2016.europython.eu/"
-          , startDate = parseDate "2016-07-17"
-          , endDate = parseDate "2016-07-24"
+          , startDate = ( 2016, Jul, 17 )
+          , endDate = ( 2016, Jul, 24 )
           , location = "Bilbao, Spain"
           , tags = [ English, Developers, Spain, Python ]
           }
         , { name = "php[cruise]"
           , link = "https://cruise.phparch.com/"
-          , startDate = parseDate "2016-07-17"
-          , endDate = parseDate "2016-07-24"
+          , startDate = ( 2016, Jul, 17 )
+          , endDate = ( 2016, Jul, 24 )
           , location = "Baltimore, MD"
           , tags = [ English, Developers, USA, PHP ]
           }
         , { name = "An Event Apart DC"
           , link = "http://aneventapart.com/event/washington-dc-2016"
-          , startDate = parseDate "2016-07-25"
-          , endDate = parseDate "2016-07-27"
+          , startDate = ( 2016, Jul, 25 )
+          , endDate = ( 2016, Jul, 27 )
           , location = "Washington, DC"
           , tags = [ English, Designers, Developers, USA, UX ]
           }
         , { name = "NDC Sydney Workshops"
           , link = "http://ndcsydney.com/"
-          , startDate = parseDate "2016-08-01"
-          , endDate = parseDate "2016-08-02"
+          , startDate = ( 2016, Aug, 1 )
+          , endDate = ( 2016, Aug, 2 )
           , location = "Sydney, Australia"
           , tags = [ English, Developers, Australia, Agile, DotNet, General ]
           }
         , { name = "NDC Sydney"
           , link = "http://ndcsydney.com/"
-          , startDate = parseDate "2016-08-03"
-          , endDate = parseDate "2016-08-05"
+          , startDate = ( 2016, Aug, 3 )
+          , endDate = ( 2016, Aug, 5 )
           , location = "Sydney, Australia"
           , tags = [ English, Developers, Australia, Agile, DotNet, General ]
           }
         , { name = "That Conference"
           , link = "https://www.thatconference.com/"
-          , startDate = parseDate "2016-08-08"
-          , endDate = parseDate "2016-08-10"
+          , startDate = ( 2016, Aug, 8 )
+          , endDate = ( 2016, Aug, 10 )
           , location = "Wisconsin Dells, WI"
           , tags = [ English, Developers, USA, Mobile, Cloud ]
           }
         , { name = "FP Conf"
           , link = "http://fpconf.org/"
-          , startDate = parseDate "2016-08-15"
-          , endDate = parseDate "2016-08-15"
+          , startDate = ( 2016, Aug, 15 )
+          , endDate = ( 2016, Aug, 15 )
           , location = "Moscow, Russia"
           , tags = [ English, Russian, Developers, Russia, FunctionalProgramming, Erlang, Scala, Clojure, Haskell ]
           }
         , { name = "360|iDev"
           , link = "http://360idev.com/"
-          , startDate = parseDate "2016-08-21"
-          , endDate = parseDate "2016-08-24"
+          , startDate = ( 2016, Aug, 21 )
+          , endDate = ( 2016, Aug, 24 )
           , location = "Denver, CO"
           , tags = [ English, Developers, USA, IOS ]
           }
         , { name = "React Rally"
           , link = "http://www.reactrally.com/"
-          , startDate = parseDate "2016-08-25"
-          , endDate = parseDate "2016-08-26"
+          , startDate = ( 2016, Aug, 25 )
+          , endDate = ( 2016, Aug, 26 )
           , location = "Salt Lake City, UT"
           , tags = [ English, Developers, USA, React, JavaScript ]
           }
         , { name = "AlterConf South Africa"
           , link = "http://www.alterconf.com/sessions/cape-town-south-africa"
-          , startDate = parseDate "2016-08-27"
-          , endDate = parseDate "2016-08-27"
+          , startDate = ( 2016, Aug, 27 )
+          , endDate = ( 2016, Aug, 27 )
           , location = "Cape Town, South Africa"
           , tags = [ English, Designers, Developers, SouthAfrica, Diversity, SoftSkills ]
           }
         , { name = "An Event Apart Chicago"
           , link = "http://aneventapart.com/event/chicago-2016"
-          , startDate = parseDate "2016-08-29"
-          , endDate = parseDate "2016-08-31"
+          , startDate = ( 2016, Aug, 29 )
+          , endDate = ( 2016, Aug, 31 )
           , location = "Chicago, IL"
           , tags = [ English, Designers, Developers, USA, UX ]
           }
         , { name = "Agile on the Beach"
           , link = "http://agileonthebeach.com/2016-2/"
-          , startDate = parseDate "2016-09-01"
-          , endDate = parseDate "2016-09-02"
+          , startDate = ( 2016, Sep, 1 )
+          , endDate = ( 2016, Sep, 2 )
           , location = "Falmouth, UK"
           , tags = [ English, Developers, UK, Agile ]
           }
         , { name = "Frontend Conference Zurich"
           , link = "https://frontendconf.ch/"
-          , startDate = parseDate "2016-09-01"
-          , endDate = parseDate "2016-09-02"
+          , startDate = ( 2016, Sep, 1 )
+          , endDate = ( 2016, Sep, 2 )
           , location = "Zürich, Switzerland"
           , tags = [ English, Designers, Switzerland, UX ]
           }
         , { name = "Full Stack Fest"
           , link = "http://2016.fullstackfest.com/"
-          , startDate = parseDate "2016-09-05"
-          , endDate = parseDate "2016-09-09"
+          , startDate = ( 2016, Sep, 5 )
+          , endDate = ( 2016, Sep, 9 )
           , location = "Barcelona, Spain"
           , tags = [ English, Developers, Spain, General ]
           }
         , { name = "iOSDevUK"
           , link = "http://www.iosdevuk.com/"
-          , startDate = parseDate "2016-09-05"
-          , endDate = parseDate "2016-09-08"
+          , startDate = ( 2016, Sep, 5 )
+          , endDate = ( 2016, Sep, 8 )
           , location = "Aberystwyth, UK"
           , tags = [ English, Developers, UK, IOS, Swift ]
           }
         , { name = "CocoaConf DC"
           , link = "http://cocoaconf.com/dc-2016/home"
-          , startDate = parseDate "2016-09-09"
-          , endDate = parseDate "2016-09-10"
+          , startDate = ( 2016, Sep, 9 )
+          , endDate = ( 2016, Sep, 10 )
           , location = "Washington, DC"
           , tags = [ English, Developers, USA, Cocoa, IOS ]
           }
         , { name = "Agile Prague"
           , link = "http://agileprague.com/"
-          , startDate = parseDate "2016-09-12"
-          , endDate = parseDate "2016-09-13"
+          , startDate = ( 2016, Sep, 12 )
+          , endDate = ( 2016, Sep, 13 )
           , location = "Prague, Czech Republic"
           , tags = [ English, Developers, CzechRepublic, Agile ]
           }
         , { name = "SwanseaCon"
           , link = "http://swanseacon.co.uk/"
-          , startDate = parseDate "2016-09-12"
-          , endDate = parseDate "2016-09-13"
+          , startDate = ( 2016, Sep, 12 )
+          , endDate = ( 2016, Sep, 13 )
           , location = "Swansea, UK"
           , tags = [ English, Developers, UK, Agile, SoftwareCraftsmanship ]
           }
         , { name = "From the Front"
           , link = "http://2016.fromthefront.it/"
-          , startDate = parseDate "2016-09-15"
-          , endDate = parseDate "2016-09-16"
+          , startDate = ( 2016, Sep, 15 )
+          , endDate = ( 2016, Sep, 16 )
           , location = "Bologna, Italy"
           , tags = [ English, Designers, Italy, UX ]
           }
         , { name = "Strangeloop"
           , link = "http://thestrangeloop.com/"
-          , startDate = parseDate "2016-09-15"
-          , endDate = parseDate "2016-09-17"
+          , startDate = ( 2016, Sep, 15 )
+          , endDate = ( 2016, Sep, 17 )
           , location = "St. Louis, MO"
           , tags = [ English, Developers, USA, General, FunctionalProgramming ]
           }
         , { name = "WindyCityRails"
           , link = "https://www.windycityrails.org/"
-          , startDate = parseDate "2016-09-15"
-          , endDate = parseDate "2016-09-16"
+          , startDate = ( 2016, Sep, 15 )
+          , endDate = ( 2016, Sep, 16 )
           , location = "Chicago, IL"
           , tags = [ English, Developers, USA, Ruby, Rails ]
           }
         , { name = "International Conference on Functional Programming"
           , link = "http://conf.researchr.org/home/icfp-2016"
-          , startDate = parseDate "2016-09-18"
-          , endDate = parseDate "2016-09-24"
+          , startDate = ( 2016, Sep, 18 )
+          , endDate = ( 2016, Sep, 24 )
           , location = "Nara, Japan"
           , tags = [ English, Developers, Japan, FunctionalProgramming, Haskell ]
           }
         , { name = "CppCon"
           , link = "http://cppcon.org/"
-          , startDate = parseDate "2016-09-18"
-          , endDate = parseDate "2016-09-23"
+          , startDate = ( 2016, Sep, 18 )
+          , endDate = ( 2016, Sep, 23 )
           , location = "Bellevue, WA"
           , tags = [ English, Developers, USA, CPlusPlus ]
           }
         , { name = "Functional Conf"
           , link = "http://functionalconf.com/"
-          , startDate = parseDate "2016-09-22"
-          , endDate = parseDate "2016-09-25"
+          , startDate = ( 2016, Sep, 22 )
+          , endDate = ( 2016, Sep, 25 )
           , location = "Bangalore, India"
           , tags = [ English, Developers, India, FunctionalProgramming ]
           }
         , { name = "DrupalCon Dublin"
           , link = "https://events.drupal.org/dublin2016/"
-          , startDate = parseDate "2016-09-26"
-          , endDate = parseDate "2016-09-30"
+          , startDate = ( 2016, Sep, 26 )
+          , endDate = ( 2016, Sep, 30 )
           , location = "Dublin, Ireland"
           , tags = [ English, Developers, Ireland, Drupal, PHP ]
           }
         , { name = "GOTO Copenhagen"
           , link = "http://gotocon.com/cph-2015/"
-          , startDate = parseDate "2016-10-03"
-          , endDate = parseDate "2016-10-06"
+          , startDate = ( 2016, Oct, 3 )
+          , endDate = ( 2016, Oct, 6 )
           , location = "Copenhagen, Denmark"
           , tags = [ English, Developers, Denmark, General ]
           }
         , { name = "An Event Apart Orlando"
           , link = "http://aneventapart.com/event/orlando-special-edition-2016"
-          , startDate = parseDate "2016-10-03"
-          , endDate = parseDate "2016-10-05"
+          , startDate = ( 2016, Oct, 3 )
+          , endDate = ( 2016, Oct, 5 )
           , location = "Orlando, FL"
           , tags = [ English, Designers, Developers, USA, UX ]
           }
         , { name = "dotGo"
           , link = "http://2016.dotgo.eu/"
-          , startDate = parseDate "2016-10-10"
-          , endDate = parseDate "2016-10-10"
+          , startDate = ( 2016, Oct, 10 )
+          , endDate = ( 2016, Oct, 10 )
           , location = "Paris, France"
           , tags = [ English, Developers, France, Go ]
           }
         , { name = "GOTO London"
           , link = "http://gotocon.com/"
-          , startDate = parseDate "2016-10-12"
-          , endDate = parseDate "2016-10-14"
+          , startDate = ( 2016, Oct, 12 )
+          , endDate = ( 2016, Oct, 14 )
           , location = "London, UK"
           , tags = [ English, Developers, UK, General ]
           }
         , { name = "ConnectJS"
           , link = "http://connect-js.com/"
-          , startDate = parseDate "2016-10-21"
-          , endDate = parseDate "2016-10-22"
+          , startDate = ( 2016, Oct, 21 )
+          , endDate = ( 2016, Oct, 22 )
           , location = "Atlanta, GA"
           , tags = [ English, Developers, USA, JavaScript ]
           }
         , { name = "Smashing Conf Barcelona"
           , link = "http://smashingconf.com/"
-          , startDate = parseDate "2016-10-25"
-          , endDate = parseDate "2016-10-26"
+          , startDate = ( 2016, Oct, 25 )
+          , endDate = ( 2016, Oct, 26 )
           , location = "Barcelona, Spain"
           , tags = [ English, Designers, Spain, UX ]
           }
         , { name = "An Event Apart San Francisco"
           , link = "http://aneventapart.com/event/san-francisco-2016"
-          , startDate = parseDate "2016-10-31"
-          , endDate = parseDate "2016-11-02"
+          , startDate = ( 2016, Oct, 31 )
+          , endDate = ( 2016, Nov, 2 )
           , location = "San Francisco, CA"
           , tags = [ English, Designers, Developers, USA, UX ]
           }
         , { name = "Beyond Tellerrand"
           , link = "http://beyondtellerrand.com/events/berlin-2016"
-          , startDate = parseDate "2016-11-07"
-          , endDate = parseDate "2016-11-09"
+          , startDate = ( 2016, Nov, 7 )
+          , endDate = ( 2016, Nov, 9 )
           , location = "Berlin, Germany"
           , tags = [ English, Designers, Developers, Germany, UX, General ]
           }
         , { name = "RubyConf"
           , link = "http://rubyconf.org/"
-          , startDate = parseDate "2016-11-10"
-          , endDate = parseDate "2016-11-12"
+          , startDate = ( 2016, Nov, 10 )
+          , endDate = ( 2016, Nov, 12 )
           , location = "Cincinnati, OH"
           , tags = [ English, Developers, USA, Ruby ]
           }
         , { name = "BuildStuff"
           , link = "http://buildstuff.lt/"
-          , startDate = parseDate "2016-11-16"
-          , endDate = parseDate "2016-11-20"
+          , startDate = ( 2016, Nov, 16 )
+          , endDate = ( 2016, Nov, 20 )
           , location = "Vilnius, Lithuania"
           , tags = [ English, Developers, Lithuania, General ]
           }
         , { name = "AWS re:Invent"
           , link = "https://reinvent.awsevents.com/"
-          , startDate = parseDate "2016-11-28"
-          , endDate = parseDate "2016-12-02"
+          , startDate = ( 2016, Nov, 28 )
+          , endDate = ( 2016, Dec, 2 )
           , location = "Las Vegas, NV"
           , tags = [ English, Developers, USA, AWS, Cloud ]
           }

--- a/src/DateFormatter.elm
+++ b/src/DateFormatter.elm
@@ -1,33 +1,32 @@
 module DateFormatter (..) where
 
-import Date
+import Date exposing (Month)
 
 
-formatRange : Date.Date -> Date.Date -> String
-formatRange startDate endDate =
+type alias DaTuple =
+    ( Int, Month, Int )
+
+
+formatRange : DaTuple -> DaTuple -> String
+formatRange ( startYear, startMonth, startDay ) ( endYear, endMonth, endDay ) =
     let
-        startMonth = Date.month startDate |> toString
+        startYear' = toString startYear
 
-        startDayOfMonth = Date.day startDate |> toString
+        startMonth' = toString startMonth
 
-        startYear = Date.year startDate |> toString
+        startDay' = toString startDay
 
-        endMonth = Date.month endDate |> toString
+        endYear' = toString endYear
 
-        endDayOfMonth = Date.day endDate |> toString
+        endMonth' = toString endMonth
 
-        endYear = Date.year endDate |> toString
+        endDay' = toString endDay
     in
-        if startYear /= endYear then
-            startMonth ++ " " ++ startDayOfMonth ++ ", " ++ startYear ++ "-" ++ endMonth ++ " " ++ endDayOfMonth ++ ", " ++ endYear
-        else if startMonth == endMonth && startDayOfMonth == endDayOfMonth then
-            startMonth ++ " " ++ startDayOfMonth ++ ", " ++ startYear
-        else if startMonth == endMonth then
-            startMonth ++ " " ++ startDayOfMonth ++ "-" ++ endDayOfMonth ++ ", " ++ startYear
+        if startYear' /= endYear' then
+            startMonth' ++ " " ++ startDay' ++ ", " ++ startYear' ++ "-" ++ endMonth' ++ " " ++ endDay' ++ ", " ++ endYear'
+        else if startMonth' == endMonth' && startDay' == endDay' then
+            startMonth' ++ " " ++ startDay' ++ ", " ++ startYear'
+        else if startMonth' == endMonth' then
+            startMonth' ++ " " ++ startDay' ++ "-" ++ endDay' ++ ", " ++ startYear'
         else
-            startMonth ++ " " ++ startDayOfMonth ++ "-" ++ endMonth ++ " " ++ endDayOfMonth ++ ", " ++ startYear
-
-
-parseDate : String -> Date.Date
-parseDate date =
-    Date.fromString date |> Result.withDefault (Date.fromTime 0)
+            startMonth' ++ " " ++ startDay' ++ "-" ++ endMonth' ++ " " ++ endDay' ++ ", " ++ startYear'

--- a/test/ConferencesTest.elm
+++ b/test/ConferencesTest.elm
@@ -1,8 +1,8 @@
 module ConferencesTest (..) where
 
 import ElmTest exposing (assertEqual, suite, test)
+import Date
 import Conferences exposing (..)
-import DateFormatter exposing (parseDate)
 
 
 tests =
@@ -33,7 +33,7 @@ tests =
             <| let
                 tags = [ Included Agile, Excluded DotNet, Included Ruby ]
 
-                blankConference = { name = "", link = "", startDate = parseDate "", endDate = parseDate "", location = "", tags = [] }
+                blankConference = { name = "", link = "", startDate = ( 1, Date.Jan, 1 ), endDate = ( 1, Date.Jan, 1 ), location = "", tags = [] }
 
                 conference1 = { blankConference | tags = [ Agile, Ruby ] }
 

--- a/test/DateFormatterTest.elm
+++ b/test/DateFormatterTest.elm
@@ -1,6 +1,6 @@
 module DateFormatterTest (..) where
 
-import Date
+import Date exposing (..)
 import ElmTest exposing (assertEqual, suite, test)
 import DateFormatter exposing (..)
 
@@ -10,30 +10,30 @@ tests =
         "DateFormatter"
         [ test "formats a single day"
             <| let
-                startDate = parseDate "1/1/2016"
+                startDate = ( 2016, Jan, 1 )
 
-                endDate = parseDate "1/1/2016"
+                endDate = ( 2016, Jan, 1 )
                in
                 assertEqual "Jan 1, 2016" <| formatRange startDate endDate
         , test "formats days within a month"
             <| let
-                startDate = parseDate "1/1/2016"
+                startDate = ( 2016, Jan, 1 )
 
-                endDate = parseDate "1/3/2016"
+                endDate = ( 2016, Jan, 3 )
                in
                 assertEqual "Jan 1-3, 2016" <| formatRange startDate endDate
         , test "formats days between months"
             <| let
-                startDate = parseDate "1/1/2016"
+                startDate = ( 2016, Jan, 1 )
 
-                endDate = parseDate "2/1/2016"
+                endDate = ( 2016, Feb, 1 )
                in
                 assertEqual "Jan 1-Feb 1, 2016" <| formatRange startDate endDate
         , test "formats days between years"
             <| let
-                startDate = parseDate "1/1/2016"
+                startDate = ( 2016, Jan, 1 )
 
-                endDate = parseDate "1/1/2017"
+                endDate = ( 2017, Jan, 1 )
                in
                 assertEqual "Jan 1, 2016-Jan 1, 2017" <| formatRange startDate endDate
         ]


### PR DESCRIPTION
Was getting weird bugs with parsing dates and then with timezones. Better to just keep any JavaScript datetime parsing out of it and just use a year/month/day tuple